### PR TITLE
Add friend function for accessing refcount

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -15,6 +15,15 @@ share {
 
 	plugin Extract => 'zip';
 
+	patch sub {
+		Path::Tiny->new("kiwi/variable.h")->edit_utf8(sub {
+			s/private:\n/$&friend int* get_refcount( kiwi::Variable* obj );/s;
+		});
+		Path::Tiny->new("kiwi/constraint.h")->edit_utf8(sub {
+			s/private:\n/$&friend int* get_refcount( kiwi::Constraint* obj );/s;
+		});
+	};
+
 	build [
 		sub {
 			my ($build) = @_;


### PR DESCRIPTION
This is needed to share the reference count so that we can store a
pointer to certain objects that use shared data.
